### PR TITLE
修改覆盖位置

### DIFF
--- a/strings/EmptyWorlds/zh-hans.po
+++ b/strings/EmptyWorlds/zh-hans.po
@@ -40,12 +40,12 @@ msgstr ""
 "\n"
 
 #. EmptyWorlds.PHO_STRINGS.I_NAME
-msgctxt "EmptyWorlds.PHO_STRINGS.E_DESCRIPTION"
+msgctxt "EmptyWorlds.PHO_STRINGS.I_NAME"
 msgid "Islands"
 msgstr "群岛小行星"
 
 #. EmptyWorlds.PHO_STRINGS.I_DESCRIPTION
-msgctxt "EmptyWorlds.PHO_STRINGS.E_DESCRIPTION"
+msgctxt "EmptyWorlds.PHO_STRINGS.I_DESCRIPTION"
 msgid ""
 "Islands is an asteroid composed of asteroids. The resources are scattered and you will have to go through space to colonize the place.\n"
 "\n"


### PR DESCRIPTION
EmptyWorld的汉化文件出现了一些问题，导致在虚无小行星上出现群岛小行星的描述+群岛小行星未翻译